### PR TITLE
Feature/cards bootstrap #41

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -27,3 +27,6 @@ vendor/
 
 # Sistema
 Thumbs.db
+
+# Air tmp folder 
+tmp/

--- a/backend/client/ygo_api.go
+++ b/backend/client/ygo_api.go
@@ -73,6 +73,8 @@ func FetchCardByIDOrName(id int, name string) (*APICard, error) {
 	return &card, nil
 }
 
+// FetchRandomCards retrieves a specified number of random Yu-Gi-Oh! cards from the YGOProDeck API.
+// It ensures that no more than MaxFetch cards are requested in a single operation.
 func FetchRandomCards(n int) ([]APICard, error) {
 	if n > MaxFetch {
 		n = MaxFetch
@@ -108,6 +110,8 @@ func FetchRandomCards(n int) ([]APICard, error) {
 	return cards, nil
 }
 
+// FetchCardsByName queries the YGOProDeck API for cards that match the given name (partial match).
+// It uses the 'fname' query parameter to perform fuzzy name search.
 func FetchCardsByName(name string) ([]APICard, error) {
 	url := fmt.Sprintf("https://db.ygoprodeck.com/api/v7/cardinfo.php?fname=%s", url.QueryEscape(name))
 	resp, err := http.Get(url)

--- a/backend/client/ygo_api.go
+++ b/backend/client/ygo_api.go
@@ -70,3 +70,34 @@ func FetchCardByIDOrName(id int, name string) (*APICard, error) {
 	card.ImageURL = card.CardImages[0].ImageURL
 	return &card, nil
 }
+
+func FetchRandomCards(n int) ([]APICard, error) {
+	url := "https://db.ygoprodeck.com/api/v7/randomcard.php"
+	var cards []APICard
+
+	for i := 0; i < n; i++ {
+		resp, err := http.Get(url)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch card %d: %w", i, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		}
+
+		var apiResp CardResponse
+		if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+			return nil, fmt.Errorf("failed to decode card %d: %w", i, err)
+		}
+
+		if len(apiResp.Data) == 0 || apiResp.Data[0].ID == 0 {
+			fmt.Println("Invalid card received")
+			continue
+		}
+
+		cards = append(cards, apiResp.Data[0])
+	}
+
+	return cards, nil
+}

--- a/backend/handlers/card_handler.go
+++ b/backend/handlers/card_handler.go
@@ -33,6 +33,8 @@ func GetOrFetchCard(c *gin.Context) {
 	c.JSON(http.StatusOK, card)
 }
 
+// GetCards is a Gin handler that retrieves a paginated list of cards from the database.
+// If the number of cards in the database is below a defined minimum, it fetches new random cards from the external API.
 func GetCards(c *gin.Context) {
 	const MinCardCount = 20
 	if err := services.EnsureMinimumCards(MinCardCount); err != nil {
@@ -55,7 +57,7 @@ func GetCards(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"totalCards": total, "cards": cards})
+	c.JSON(http.StatusOK, gin.H{"totalCards": total, "Some cards": cards})
 }
 
 // SearchCards handles GET requests to search cards in the database.

--- a/backend/handlers/card_handler.go
+++ b/backend/handlers/card_handler.go
@@ -32,3 +32,28 @@ func GetOrFetchCard(c *gin.Context) {
 
 	c.JSON(http.StatusOK, card)
 }
+
+func GetCards(c *gin.Context) {
+	const MinCardCount = 20
+	if err := services.EnsureMinimumCards(MinCardCount); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to ensure minimum card stock"})
+		return
+	}
+
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+
+	cards, err := services.GetCards(limit, offset)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve cards"})
+		return
+	}
+
+	total, err := services.CountAllCards()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count all cards"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"totalCards": total, "cards": cards})
+}

--- a/backend/handlers/card_handler.go
+++ b/backend/handlers/card_handler.go
@@ -58,23 +58,23 @@ func GetCards(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"totalCards": total, "cards": cards})
 }
 
-func GetFilteredCards(c *gin.Context) {
+// SearchCards handles GET requests to search cards in the database.
+// It filters by name, type, and archetype. If no results are found locally,
+// it tries to fetch similar cards from the external YGOProDeck API.
+func SearchCards(c *gin.Context) {
 	name := c.Query("name")
 	cardType := c.Query("type")
 	archetype := c.Query("archetype")
 
-	// Límite y offset para paginación
 	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
 	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
 
-	// Buscar en la base de datos
 	cards, err := services.GetFilteredCards(name, cardType, archetype, limit, offset)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve cards from database"})
 		return
 	}
 
-	// Si no se encontraron cartas y hay un nombre, buscar en la API
 	if len(cards) == 0 && name != "" {
 		fetchedCards, err := services.FetchAndStoreCardsByName(name)
 		if err != nil {

--- a/backend/routes/router.go
+++ b/backend/routes/router.go
@@ -42,6 +42,7 @@ func SetupRouter() *gin.Engine {
 		cards.Use(middleware.AuthMiddleware())
 		{
 			cards.GET("/", handlers.GetCards)
+			cards.GET("/search", handlers.GetFilteredCards)
 			cards.GET("/:param", handlers.GetOrFetchCard) // Get new card
 		}
 		auth := api.Group("/auth")

--- a/backend/routes/router.go
+++ b/backend/routes/router.go
@@ -42,7 +42,7 @@ func SetupRouter() *gin.Engine {
 		cards.Use(middleware.AuthMiddleware())
 		{
 			cards.GET("/", handlers.GetCards)
-			cards.GET("/search", handlers.GetFilteredCards)
+			cards.GET("/search", handlers.SearchCards)
 			cards.GET("/:param", handlers.GetOrFetchCard) // Get new card
 		}
 		auth := api.Group("/auth")

--- a/backend/routes/router.go
+++ b/backend/routes/router.go
@@ -41,6 +41,7 @@ func SetupRouter() *gin.Engine {
 		cards := api.Group("/cards")
 		cards.Use(middleware.AuthMiddleware())
 		{
+			cards.GET("/", handlers.GetCards)
 			cards.GET("/:param", handlers.GetOrFetchCard) // Get new card
 		}
 		auth := api.Group("/auth")

--- a/backend/services/card_service.go
+++ b/backend/services/card_service.go
@@ -144,17 +144,15 @@ func EnsureMinimumCards(min int) error {
 			continue
 		}
 
-		// Comprobar duplicados
 		var existing models.Card
 		err := database.DB.Where("card_ygo_id = ?", apiCard.ID).First(&existing).Error
 		if err == nil {
-			continue // ya existe
+			continue
 		}
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return fmt.Errorf("error checking card: %w", err)
 		}
 
-		// Obtener imagen
 		imageURL := ""
 		if len(apiCard.CardImages) > 0 {
 			imageURL = apiCard.CardImages[0].ImageURL
@@ -174,6 +172,8 @@ func EnsureMinimumCards(min int) error {
 	return nil
 }
 
+// GetCardsByFilters returns cards filtered by name, type, and archetype from the database.
+// If no cards match, it attempts to fetch new ones from the external API and save them.
 func GetFilteredCards(name, cardType, archetype string, limit, offset int) ([]models.Card, error) {
 	db := database.DB.Model(&models.Card{}).
 		Preload("MonsterCard").
@@ -222,7 +222,6 @@ func FetchAndStoreCardsByName(name string) ([]models.Card, error) {
 
 	var stored []models.Card
 	for _, apiCard := range apiCards {
-		// Validación mínima
 		if apiCard.ID == 0 || apiCard.Name == "" {
 			continue
 		}
@@ -237,7 +236,6 @@ func FetchAndStoreCardsByName(name string) ([]models.Card, error) {
 			continue
 		}
 
-		// Subida de imagen a S3
 		s3URL, err := utils.UploadCardImageToS3(apiCard.ID, apiCard.CardImages[0].ImageURL)
 		if err != nil {
 			continue


### PR DESCRIPTION
This PR introduces logic to ensure a minimum set of cards is available in the database. It fetches random cards from the YGOProDeck API and stores them if necessary. Additionally, it includes a new /api/cards endpoint with support for pagination and basic filtering by name, type, and archetype

- EnsureMinimumCards service to populate the DB if needed
- Fetch and store logic for random and searched cards
- /api/cards and /api/cards/search endpoints with pagination

Closes #41 