### PR TITLE
Tests/add integration tests for user handler #51

### DIFF
--- a/backend/handlers/user_handler.go
+++ b/backend/handlers/user_handler.go
@@ -35,6 +35,9 @@ func CreateUser(c *gin.Context) {
 		return
 	}
 
+	// Clear password before sending response
+	user.Password = ""
+
 	c.JSON(http.StatusCreated, gin.H{"user": user})
 }
 

--- a/backend/tests/api_tests/user_handler_test.go
+++ b/backend/tests/api_tests/user_handler_test.go
@@ -1,0 +1,93 @@
+package api_tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Grajal/SW2-YugiCollectionManager/backend/models"
+	api_clients "github.com/Grajal/SW2-YugiCollectionManager/backend/tests/clients"
+	"github.com/Grajal/SW2-YugiCollectionManager/backend/tests/factories"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateUser(t *testing.T) {
+	client := api_clients.NewTestClient(false)
+
+	payload := map[string]interface{}{
+		"username": "testuser123",
+		"email":    "testuser123@example.com",
+		"password": "password123",
+	}
+
+	res := client.PerformRequest("POST", "/api/users/", payload, nil)
+
+	assert.Equal(t, http.StatusCreated, res.Code)
+
+	var body map[string]models.User
+	err := json.Unmarshal(res.Body.Bytes(), &body)
+	assert.NoError(t, err)
+
+	user := body["user"]
+	assert.Equal(t, "testuser123", user.Username)
+	assert.Equal(t, "testuser123@example.com", user.Email)
+	assert.Empty(t, user.Password)
+}
+
+func TestGetUserByName_Success(t *testing.T) {
+	client := api_clients.NewTestClient(false)
+	user := factories.UserFactory()
+
+	res := client.PerformRequest("GET", "/api/users/"+user.Username, nil, nil)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+
+	var body map[string]models.User
+	err := json.Unmarshal(res.Body.Bytes(), &body)
+	assert.NoError(t, err)
+
+	returnedUser := body["user"]
+	assert.Equal(t, user.Username, returnedUser.Username)
+	assert.Equal(t, user.Email, returnedUser.Email)
+	assert.Empty(t, returnedUser.Password)
+}
+
+func TestGetUserByName_NotFound(t *testing.T) {
+	client := api_clients.NewTestClient(false)
+
+	res := client.PerformRequest("GET", "/api/users/unknownuser", nil, nil)
+
+	assert.Equal(t, http.StatusNotFound, res.Code)
+
+	var body map[string]string
+	err := json.Unmarshal(res.Body.Bytes(), &body)
+	assert.NoError(t, err)
+	assert.Contains(t, body["error"], "user not found")
+}
+
+func TestDeleteUser_Success(t *testing.T) {
+	client := api_clients.NewTestClient(false)
+	user := factories.UserFactory()
+
+	res := client.PerformRequest("DELETE", "/api/users/"+user.Username, nil, nil)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+
+	var body map[string]string
+	err := json.Unmarshal(res.Body.Bytes(), &body)
+	assert.NoError(t, err)
+	assert.Equal(t, "user deleted successfully", body["message"])
+}
+
+func TestDeleteUser_NotFound(t *testing.T) {
+	client := api_clients.NewTestClient(false)
+
+	res := client.PerformRequest("DELETE", "/api/users/doesnotexist", nil, nil)
+
+	assert.Equal(t, http.StatusNotFound, res.Code)
+
+	var body map[string]string
+	err := json.Unmarshal(res.Body.Bytes(), &body)
+	assert.NoError(t, err)
+	assert.Contains(t, body["error"], "user not found")
+}


### PR DESCRIPTION
## ✨ Add integration tests for user handler

Closes #51

### 📋 Summary

This PR adds integration tests for the user-related endpoints in `user_handler.go`, including:

- `POST /api/users/` – Create a new user
- `GET /api/users/:username` – Retrieve user by username
- `DELETE /api/users/:username` – Delete user by username

### ✅ What was added

- ✅ Integration test for user creation
  - Verifies correct status code and response body
  - Asserts password is omitted in the response
- ✅ Test for retrieving user by username
- ✅ Test for deleting a user
- 🔄 Handler updated to omit password field from the create response

### 🧪 Coverage

All major success and failure cases are covered:
- User creation with valid input
- Fetching existing and non-existing users
- Deleting existing and non-existing users

### 🧹 Notes

- Password hash is now removed before responding to avoid leaking sensitive data.
- Uses `UserFactory()` to create mock users for tests.
- Uses the shared test client for consistency.
