### PR TITLE
Feature/backend decks export #28

### DIFF
--- a/backend/handlers/deck_handler.go
+++ b/backend/handlers/deck_handler.go
@@ -172,6 +172,9 @@ func RemoveCardFromDeck(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Card removed from deck"})
 }
 
+// Allows you to export a deck in .ydk format for use in clients such as EDOPro.
+// according to their number in the deck. (card_ygo_id) of each card, repeated
+// according to their quantity in the deck.
 func ExportDeckHandler(c *gin.Context) {
 	userID := c.MustGet("user_id").(uint)
 	deckIDStr := c.Param("deckId")

--- a/backend/handlers/deck_handler.go
+++ b/backend/handlers/deck_handler.go
@@ -171,3 +171,22 @@ func RemoveCardFromDeck(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "Card removed from deck"})
 }
+
+func ExportDeckHandler(c *gin.Context) {
+	userID := c.MustGet("user_id").(uint)
+	deckIDStr := c.Param("deckId")
+	deckID, err := strconv.ParseUint(deckIDStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid deck ID"})
+		return
+	}
+
+	ydkContent, err := services.ExportDeckAsYDK(userID, uint(deckID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Header("Content-Disposition", "attachment; filename=deck.ydk")
+	c.Data(http.StatusOK, "text/plain", []byte(ydkContent))
+}

--- a/backend/models/deck_card.go
+++ b/backend/models/deck_card.go
@@ -4,10 +4,10 @@ import "gorm.io/gorm"
 
 type DeckCard struct {
 	gorm.Model
-	DeckID      uint
-	CardID      uint
-	Quantity    int `gorm:"not null"`
-	IsExtraDeck bool
+	DeckID   uint
+	CardID   uint
+	Quantity int    `gorm:"not null"`
+	Zone     string `gorm:"type:varchar(10);not null"`
 
 	Card Card `gorm:"foreignKey:CardID"`
 }

--- a/backend/routes/router.go
+++ b/backend/routes/router.go
@@ -68,8 +68,9 @@ func SetupRouter() *gin.Engine {
 		decks := api.Group("/decks")
 		decks.Use(middleware.AuthMiddleware())
 		{
-			decks.POST("/", handlers.CreateDeck)
 			decks.GET("/", handlers.GetUserDecks)
+			decks.POST("/", handlers.CreateDeck)
+			decks.POST("/:deckId/export", handlers.ExportDeckHandler)
 			decks.GET("/:deckId/cards", handlers.GetCardByDeck)
 			decks.POST("/:deckId/cards", handlers.AddCardToDeck)
 			decks.DELETE("/:deckId", handlers.DeleteDeck)

--- a/backend/services/deck_card_service.go
+++ b/backend/services/deck_card_service.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Grajal/SW2-YugiCollectionManager/backend/database"
 	"github.com/Grajal/SW2-YugiCollectionManager/backend/models"
@@ -39,9 +38,9 @@ func AddCardToDeck(userID uint, deckID uint, cardID uint, quantity int) (*models
 		return nil, fmt.Errorf("card not found: %w", err)
 	}
 
-	isExtra := IsExtraDeckCard(card.FrameType)
+	zone := GetZoneFromCard(card)
 
-	if err := ValidateDeckCardCount(deck.ID, isExtra, quantity); err != nil {
+	if err := ValidateDeckCardCount(deck.ID, zone, quantity); err != nil {
 		return nil, err
 	}
 
@@ -65,10 +64,10 @@ func AddCardToDeck(userID uint, deckID uint, cardID uint, quantity int) (*models
 	}
 
 	newEntry := models.DeckCard{
-		DeckID:      deckID,
-		CardID:      card.ID,
-		Quantity:    quantity,
-		IsExtraDeck: isExtra,
+		DeckID:   deckID,
+		CardID:   card.ID,
+		Quantity: quantity,
+		Zone:     zone,
 	}
 
 	if err := database.DB.Create(&newEntry).Error; err != nil {
@@ -78,12 +77,12 @@ func AddCardToDeck(userID uint, deckID uint, cardID uint, quantity int) (*models
 	return &newEntry, nil
 }
 
-func IsExtraDeckCard(frameType string) bool {
-	switch strings.ToLower(frameType) {
+func GetZoneFromCard(card *models.Card) string {
+	switch card.FrameType {
 	case "link", "xyz", "fusion", "synchro":
-		return true
+		return "extra"
 	default:
-		return false
+		return "main"
 	}
 }
 
@@ -116,9 +115,9 @@ func RemoveCardFromDeck(userID, deckID, cardID uint, quantity int) error {
 	return nil
 }
 
-func ValidateDeckCardCount(deckID uint, isExtra bool, newCards int) error {
+func ValidateDeckCardCount(deckID uint, zone string, newCards int) error {
 	var total sql.NullInt64
-	query := database.DB.Model(&models.DeckCard{}).Where("deck_id = ? AND is_extra_deck = ?", deckID, isExtra).Select("SUM(quantity)").Scan(&total)
+	query := database.DB.Model(&models.DeckCard{}).Where("deck_id = ? AND zone = ?", deckID, zone).Select("SUM(quantity)").Scan(&total)
 	if query.Error != nil {
 		return query.Error
 	}
@@ -128,10 +127,10 @@ func ValidateDeckCardCount(deckID uint, isExtra bool, newCards int) error {
 		sum = total.Int64
 	}
 
-	if isExtra && sum+int64(newCards) > 20 {
+	if zone == "extra" && sum+int64(newCards) > 20 {
 		return ErrExtraDeckLimitReached
 	}
-	if !isExtra && sum+int64(newCards) > 60 {
+	if zone == "main" && sum+int64(newCards) > 60 {
 		return ErrDeckLimitReached
 	}
 	return nil

--- a/backend/services/deck_service.go
+++ b/backend/services/deck_service.go
@@ -56,11 +56,11 @@ func getDeckByIDAndUserID(deckID, userID uint) (*models.Deck, error) {
 func GetDecksByUserID(userID uint) ([]models.Deck, error) {
 	var decks []models.Deck
 	err := database.DB.Where("user_id = ?", userID).Preload("DeckCards").
-		Preload("DeckCards.Card").
 		Preload("DeckCards.Card.MonsterCard").
 		Preload("DeckCards.Card.SpellTrapCard").
 		Preload("DeckCards.Card.LinkMonsterCard").
-		Preload("DeckCards.Card.PendulumMonsterCard").Find(&decks).Error
+		Preload("DeckCards.Card.PendulumMonsterCard").
+		Preload("DeckCards.Card").Find(&decks).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch decks: %w", err)
 	}


### PR DESCRIPTION
This PR adds support for exporting user decks to the .ydk format, compatible with platforms such as EdoPro.

- Refactoring of the DeckCard model to replace isExtraDeck by the Zone field.
- New GET /decks/:deckID/export path protected with JWT.
- ExportDeckHandler implementation that delivers the deck as a downloadable file.
- Support for #main, #extra and #side sections based on the zone of each chart.

Related to #28 