### PR TITLE
Feature/add card collection statistics #57

### DIFF
--- a/backend/handlers/collection_handler.go
+++ b/backend/handlers/collection_handler.go
@@ -109,3 +109,15 @@ func DeleteQuantityCardsFromCollcetion(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "Card quantity updated or removed succesfully"})
 }
+
+func GetCollectionStats(c *gin.Context) {
+	userID := c.MustGet("user_id").(uint)
+
+	stats, err := services.CalculateCollectionStats(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not calculate stats"})
+		return
+	}
+
+	c.JSON(http.StatusOK, stats)
+}

--- a/backend/routes/router.go
+++ b/backend/routes/router.go
@@ -63,6 +63,7 @@ func SetupRouter() *gin.Engine {
 			collections.GET("/", handlers.GetColletion) // Get collection
 			collections.POST("/", handlers.AddCardToCollection)
 			collections.DELETE("/:cardId", handlers.DeleteQuantityCardsFromCollcetion)
+			collections.GET("/stats", handlers.GetCollectionStats)
 		}
 
 		decks := api.Group("/decks")

--- a/backend/services/collection_service.go
+++ b/backend/services/collection_service.go
@@ -3,7 +3,6 @@ package services
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Grajal/SW2-YugiCollectionManager/backend/database"
 	"github.com/Grajal/SW2-YugiCollectionManager/backend/models"
@@ -80,41 +79,4 @@ func DeleteQuantityCardFromCollection(userID, cardID uint, quantityToRemove int)
 	}
 
 	return database.DB.Delete(&userCard).Error
-}
-
-type CollectionStats struct {
-	MonsterCount int `json:"monster"`
-	SpellCount   int `json:"spell"`
-	TrapCount    int `json:"trap"`
-}
-
-// CalculateCollectionStats computes card type distribution for a user's collection.
-func CalculateCollectionStats(userID uint) (CollectionStats, error) {
-	userCards, err := GetCollectionByUserID(userID)
-	if err != nil {
-		return CollectionStats{}, err
-	}
-
-	stats := CollectionStats{}
-
-	for _, uc := range userCards {
-		cardType := uc.Card.Type
-		quantity := uc.Quantity
-
-		switch {
-		case containsIgnoreCase(cardType, "monster"):
-			stats.MonsterCount += quantity
-		case containsIgnoreCase(cardType, "spell"):
-			stats.SpellCount += quantity
-		case containsIgnoreCase(cardType, "trap"):
-			stats.TrapCount += quantity
-		}
-	}
-
-	return stats, nil
-}
-
-// Helper function to match type regardless of case
-func containsIgnoreCase(s, substr string) bool {
-	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
 }

--- a/backend/services/collection_service.go
+++ b/backend/services/collection_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Grajal/SW2-YugiCollectionManager/backend/database"
 	"github.com/Grajal/SW2-YugiCollectionManager/backend/models"
@@ -79,4 +80,41 @@ func DeleteQuantityCardFromCollection(userID, cardID uint, quantityToRemove int)
 	}
 
 	return database.DB.Delete(&userCard).Error
+}
+
+type CollectionStats struct {
+	MonsterCount int `json:"monster"`
+	SpellCount   int `json:"spell"`
+	TrapCount    int `json:"trap"`
+}
+
+// CalculateCollectionStats computes card type distribution for a user's collection.
+func CalculateCollectionStats(userID uint) (CollectionStats, error) {
+	userCards, err := GetCollectionByUserID(userID)
+	if err != nil {
+		return CollectionStats{}, err
+	}
+
+	stats := CollectionStats{}
+
+	for _, uc := range userCards {
+		cardType := uc.Card.Type
+		quantity := uc.Quantity
+
+		switch {
+		case containsIgnoreCase(cardType, "monster"):
+			stats.MonsterCount += quantity
+		case containsIgnoreCase(cardType, "spell"):
+			stats.SpellCount += quantity
+		case containsIgnoreCase(cardType, "trap"):
+			stats.TrapCount += quantity
+		}
+	}
+
+	return stats, nil
+}
+
+// Helper function to match type regardless of case
+func containsIgnoreCase(s, substr string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
 }

--- a/backend/services/stats_service.go
+++ b/backend/services/stats_service.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"strings"
+
+	"github.com/Grajal/SW2-YugiCollectionManager/backend/models"
 )
 
 type AvgStats struct {
@@ -17,62 +19,96 @@ type CollectionStats struct {
 	AverageStats AvgStats       `json:"average_stats"`
 }
 
+// CalculateCollectionStats returns overall statistics for a user's card collection,
+// including counts of monsters, spells, and traps, monster attribute distribution,
+// and average ATK/DEF for monster cards.
 func CalculateCollectionStats(userID uint) (CollectionStats, error) {
 	userCards, err := GetCollectionByUserID(userID)
 	if err != nil {
 		return CollectionStats{}, err
 	}
 
-	stats := CollectionStats{
-		Attributes: make(map[string]int),
-	}
+	monsterCount, spellCount, trapCount := countCardTypes(userCards)
+	attributes := countMonsterAttributes(userCards)
+	avgStats := computeAverageStats(userCards)
 
-	var (
-		totalATK    int
-		totalDEF    int
-		atkDefCount int
-	)
+	return CollectionStats{
+		MonsterCount: monsterCount,
+		SpellCount:   spellCount,
+		TrapCount:    trapCount,
+		Attributes:   attributes,
+		AverageStats: avgStats,
+	}, nil
+}
+
+// countCardTypes calculates the total number of Monster, Spell, and Trap cards
+// in the user's collection based on card type and quantity.
+func countCardTypes(userCards []models.UserCard) (int, int, int) {
+	var monsterCount, spellCount, trapCount int
 
 	for _, uc := range userCards {
+		qty := uc.Quantity
 		cardType := uc.Card.Type
-		quantity := uc.Quantity
 
 		switch {
 		case containsIgnoreCase(cardType, "monster"):
-			stats.MonsterCount += quantity
-
-			// Monster-specific logic
-			if uc.Card.MonsterCard != nil {
-				attr := strings.ToUpper(uc.Card.MonsterCard.Attribute)
-				if attr != "" {
-					stats.Attributes[attr] += quantity
-				}
-
-				atk := uc.Card.MonsterCard.Atk
-				def := uc.Card.MonsterCard.Def
-
-				if atk >= 0 {
-					totalATK += atk * quantity
-				}
-				if def >= 0 {
-					totalDEF += def * quantity
-				}
-
-				atkDefCount += quantity
-			}
+			monsterCount += qty
 		case containsIgnoreCase(cardType, "spell"):
-			stats.SpellCount += quantity
+			spellCount += qty
 		case containsIgnoreCase(cardType, "trap"):
-			stats.TrapCount += quantity
+			trapCount += qty
 		}
 	}
 
-	if atkDefCount > 0 {
-		stats.AverageStats.AvgATK = float64(totalATK) / float64(atkDefCount)
-		stats.AverageStats.AvgDEF = float64(totalDEF) / float64(atkDefCount)
+	return monsterCount, spellCount, trapCount
+}
+
+// countMonsterAttributes returns a map of monster attributes (e.g., DARK, LIGHT)
+// and their respective total quantities in the user's collection.
+func countMonsterAttributes(userCards []models.UserCard) map[string]int {
+	attributes := make(map[string]int)
+
+	for _, uc := range userCards {
+		if uc.Card.MonsterCard != nil {
+			attr := strings.ToUpper(uc.Card.MonsterCard.Attribute)
+			if attr != "" {
+				attributes[attr] += uc.Quantity
+			}
+		}
 	}
 
-	return stats, nil
+	return attributes
+}
+
+// computeAverageStats calculates the average ATK and DEF values for all Monster cards
+// in the user's collection, weighted by the quantity of each card.
+func computeAverageStats(userCards []models.UserCard) AvgStats {
+	var totalATK, totalDEF, count int
+
+	for _, uc := range userCards {
+		qty := uc.Quantity
+		if uc.Card.MonsterCard != nil {
+			atk := uc.Card.MonsterCard.Atk
+			def := uc.Card.MonsterCard.Def
+
+			if atk >= 0 {
+				totalATK += atk * qty
+			}
+			if def >= 0 {
+				totalDEF += def * qty
+			}
+			count += qty
+		}
+	}
+
+	if count == 0 {
+		return AvgStats{}
+	}
+
+	return AvgStats{
+		AvgATK: float64(totalATK) / float64(count),
+		AvgDEF: float64(totalDEF) / float64(count),
+	}
 }
 
 // Helper function to match type regardless of case

--- a/backend/services/stats_service.go
+++ b/backend/services/stats_service.go
@@ -1,0 +1,53 @@
+package services
+
+import (
+	"strings"
+)
+
+type CollectionStats struct {
+	MonsterCount int            `json:"monster"`
+	SpellCount   int            `json:"spell"`
+	TrapCount    int            `json:"trap"`
+	Attributes   map[string]int `json:"attributes"`
+}
+
+// CalculateCollectionStats computes card type distribution for a user's collection.
+func CalculateCollectionStats(userID uint) (CollectionStats, error) {
+	userCards, err := GetCollectionByUserID(userID)
+	if err != nil {
+		return CollectionStats{}, err
+	}
+
+	stats := CollectionStats{
+		Attributes: make(map[string]int),
+	}
+
+	for _, uc := range userCards {
+		cardType := uc.Card.Type
+		quantity := uc.Quantity
+
+		switch {
+		case containsIgnoreCase(cardType, "monster"):
+			stats.MonsterCount += quantity
+
+			// Check MonsterCard details
+			if uc.Card.MonsterCard != nil {
+				attr := strings.ToUpper(uc.Card.MonsterCard.Attribute)
+				if attr != "" {
+					stats.Attributes[attr] += quantity
+				}
+			}
+		case containsIgnoreCase(cardType, "spell"):
+			stats.SpellCount += quantity
+		case containsIgnoreCase(cardType, "trap"):
+			stats.TrapCount += quantity
+		}
+	}
+
+	return stats, nil
+}
+
+// Helper function to match type regardless of case
+func containsIgnoreCase(s, substr string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}

--- a/backend/services/stats_service_test.go
+++ b/backend/services/stats_service_test.go
@@ -1,0 +1,70 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/Grajal/SW2-YugiCollectionManager/backend/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountCardTypes(t *testing.T) {
+	userCards := []models.UserCard{
+		{Card: models.Card{Type: "Monster"}, Quantity: 3},
+		{Card: models.Card{Type: "Spell Card"}, Quantity: 2},
+		{Card: models.Card{Type: "Trap"}, Quantity: 1},
+	}
+
+	monsters, spells, traps := countCardTypes(userCards)
+
+	assert.Equal(t, 3, monsters)
+	assert.Equal(t, 2, spells)
+	assert.Equal(t, 1, traps)
+}
+
+func TestCountMonsterAttributes(t *testing.T) {
+	userCards := []models.UserCard{
+		{
+			Quantity: 2,
+			Card: models.Card{
+				Type:        "Monster",
+				MonsterCard: &models.MonsterCard{Attribute: "DARK"},
+			},
+		},
+		{
+			Quantity: 1,
+			Card: models.Card{
+				Type:        "Monster",
+				MonsterCard: &models.MonsterCard{Attribute: "LIGHT"},
+			},
+		},
+	}
+
+	attrs := countMonsterAttributes(userCards)
+
+	assert.Equal(t, 2, attrs["DARK"])
+	assert.Equal(t, 1, attrs["LIGHT"])
+}
+
+func TestComputeAverageStats(t *testing.T) {
+	userCards := []models.UserCard{
+		{
+			Quantity: 2,
+			Card: models.Card{
+				Type:        "Monster",
+				MonsterCard: &models.MonsterCard{Atk: 2000, Def: 1500},
+			},
+		},
+		{
+			Quantity: 1,
+			Card: models.Card{
+				Type:        "Monster",
+				MonsterCard: &models.MonsterCard{Atk: 1000, Def: 1200},
+			},
+		},
+	}
+
+	avg := computeAverageStats(userCards)
+
+	assert.InEpsilon(t, 1666.6, avg.AvgATK, 0.1)
+	assert.InEpsilon(t, 1400.0, avg.AvgDEF, 0.1)
+}


### PR DESCRIPTION
# Feature: Add Card Collection Statistics (#57)

## 📌 Summary

This PR adds the initial **statistics system** for the user's card collection. It introduces a dedicated `stats` service that calculates useful insights about the cards owned by a user.

---

## ✅ What's Included

### 🎯 Core Statistics Implemented
- **Card Type Distribution**
  - Total number of Monster, Spell, and Trap cards (based on quantity).
- **Monster Attribute Distribution**
  - Count of monster cards per attribute (e.g., DARK, LIGHT, FIRE).
- **Average Monster Stats**
  - Weighted average ATK and DEF for all monster cards in the collection.

### 🧠 Service Logic
- New `services/stats.go` file with a clear separation of logic:
  - `CalculateCollectionStats`
  - `countCardTypes`
  - `countMonsterAttributes`
  - `computeAverageStats`

### 🔬 Unit Tests
- Added `stats_test.go` with full test coverage for:
  - Card type counting
  - Attribute distribution
  - Average ATK/DEF calculation


---

## 📡 API Changes

### `GET /api/collections/stats`
- **Auth Required**: ✅
- **Response**:
```json
{
  "monster": 15,
  "spell": 8,
  "trap": 3,
  "attributes": {
    "DARK": 5,
    "LIGHT": 4,
    "WIND": 6
  },
  "averageStats": {
    "avgATK": 1780.33,
    "avgDEF": 1450.25
  }
}