### PR TITLE
Feature/backend import #28

### DIFF
--- a/backend/handlers/deck_handler.go
+++ b/backend/handlers/deck_handler.go
@@ -193,3 +193,28 @@ func ExportDeckHandler(c *gin.Context) {
 	c.Header("Content-Disposition", "attachment; filename=deck.ydk")
 	c.Data(http.StatusOK, "text/plain", []byte(ydkContent))
 }
+
+func ImportDeckHandler(c *gin.Context) {
+	userID := c.MustGet("user_id").(uint)
+
+	deckIDParam := c.Param("deckId")
+	deckID, err := strconv.ParseUint(deckIDParam, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid deck ID"})
+		return
+	}
+
+	file, _, err := c.Request.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read file"})
+		return
+	}
+
+	err = services.ImportDeckFromYDK(userID, uint(deckID), file)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to import deck: %v", err)})
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/backend/models/deck.go
+++ b/backend/models/deck.go
@@ -1,9 +1,7 @@
 package models
 
-import "gorm.io/gorm"
-
 type Deck struct {
-	gorm.Model
+	ID          uint `gorm:"primaryKey"`
 	UserID      uint
 	Name        string `gorm:"not null"`
 	Description string

--- a/backend/models/deck_card.go
+++ b/backend/models/deck_card.go
@@ -1,13 +1,10 @@
 package models
 
-import "gorm.io/gorm"
-
 type DeckCard struct {
-	gorm.Model
-	DeckID   uint
-	CardID   uint
+	DeckID   uint   `gorm:"primaryKey"`
+	CardID   uint   `gorm:"primaryKey"`
 	Quantity int    `gorm:"not null"`
 	Zone     string `gorm:"type:varchar(10);not null"`
 
-	Card Card `gorm:"foreignKey:CardID"`
+	Card Card `gorm:"foreignKey:CardID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 }

--- a/backend/models/link_monster_card.go
+++ b/backend/models/link_monster_card.go
@@ -1,9 +1,6 @@
 package models
 
-import "gorm.io/gorm"
-
 type LinkMonsterCard struct {
-	gorm.Model
 	CardID      uint `gorm:"primaryKey;contraint: OnUpdate:CASCADE,OnDelete:CASCADE"`
 	LinkValue   int
 	LinkMarkers string `gorm:"type:jsonb"`

--- a/backend/models/monster_card.go
+++ b/backend/models/monster_card.go
@@ -1,9 +1,6 @@
 package models
 
-import "gorm.io/gorm"
-
 type MonsterCard struct {
-	gorm.Model
 	CardID    uint `gorm:"primaryKey;contraint: OnUpdate:CASCADE,OnDelete:CASCADE"`
 	Atk       int
 	Def       int

--- a/backend/models/pendulum_monster_card.go
+++ b/backend/models/pendulum_monster_card.go
@@ -1,9 +1,6 @@
 package models
 
-import "gorm.io/gorm"
-
 type PendulumMonsterCard struct {
-	gorm.Model
 	CardID    uint `gorm:"primaryKey;contraint: OnUpdate:CASCADE,OnDelete:CASCADE"`
 	Scale     int
 	Atk       int

--- a/backend/models/spell_trap_card.go
+++ b/backend/models/spell_trap_card.go
@@ -1,9 +1,6 @@
 package models
 
-import "gorm.io/gorm"
-
 type SpellTrapCard struct {
-	gorm.Model
 	CardID uint `gorm:"primaryKey;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Type   string
 }

--- a/backend/models/user.go
+++ b/backend/models/user.go
@@ -1,12 +1,10 @@
 // Package models contains data structures representing system entities
 package models
 
-import "gorm.io/gorm"
-
 // User represents a system user
 // Contains basic user information and its relationships with collections and decks
 type User struct {
-	gorm.Model
+	ID       uint   `gorm:"primaryKey"`
 	Username string `gorm:"unique;not null"`
 	Email    string `gorm:"unique;not null"`
 	Password string // Hashed password

--- a/backend/routes/router.go
+++ b/backend/routes/router.go
@@ -70,7 +70,8 @@ func SetupRouter() *gin.Engine {
 		{
 			decks.GET("/", handlers.GetUserDecks)
 			decks.POST("/", handlers.CreateDeck)
-			decks.POST("/:deckId/export", handlers.ExportDeckHandler)
+			decks.POST("/import/:deckId", handlers.ImportDeckHandler)
+			decks.POST("/export/:deckId", handlers.ExportDeckHandler)
 			decks.GET("/:deckId/cards", handlers.GetCardByDeck)
 			decks.POST("/:deckId/cards", handlers.AddCardToDeck)
 			decks.DELETE("/:deckId", handlers.DeleteDeck)

--- a/backend/utils/ydk_parser.go
+++ b/backend/utils/ydk_parser.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"bufio"
+	"io"
+	"mime/multipart"
+	"strings"
+)
+
+func ParseYDK(file multipart.File) ([]string, []string, []string, error) {
+	var (
+		mainIDs  []string
+		extraIDs []string
+		sideIDs  []string
+		current  *[]string
+	)
+
+	reader := bufio.NewReader(file)
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return nil, nil, nil, err
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#created") {
+			if err == io.EOF {
+				break
+			}
+			continue
+		}
+
+		switch line {
+		case "#main":
+			current = &mainIDs
+		case "#extra":
+			current = &extraIDs
+		case "#side":
+			current = &sideIDs
+		default:
+			if current == nil {
+				// Alternativa: log.Printf("Ignoring line outside of section: %s", line)
+				continue
+			}
+			*current = append(*current, line)
+		}
+
+		if err == io.EOF {
+			break
+		}
+	}
+
+	return mainIDs, extraIDs, sideIDs, nil
+}


### PR DESCRIPTION
Implemented the functionality to import cards to a deck from a .ydk file or by passing the YGOProDeck ID.

- Parser .ydk based on YGOProDeck IDs.
- Fetch cards from external API if they do not exist locally.
- Modifications in the model, for better database logic.
- Handler and endpoint /api/decks/import/:deckId

Closes #28 