### PR TITLE
Feature/add deck stats #66

### DIFF
--- a/backend/handlers/deck_handler.go
+++ b/backend/handlers/deck_handler.go
@@ -218,3 +218,22 @@ func ImportDeckHandler(c *gin.Context) {
 
 	c.Status(http.StatusNoContent)
 }
+
+func GetDeckStats(c *gin.Context) {
+	userID := c.MustGet("user_id").(uint)
+
+	deckID, err := strconv.Atoi(c.Param("deckId"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid deck ID"})
+		return
+	}
+
+	deckCards, err := services.GetCardsByDeck(userID, uint(deckID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not fetch deck cards"})
+		return
+	}
+
+	stats := services.CalculateDeckStats(deckCards)
+	c.JSON(http.StatusOK, stats)
+}

--- a/backend/routes/router.go
+++ b/backend/routes/router.go
@@ -77,6 +77,7 @@ func SetupRouter() *gin.Engine {
 			decks.POST("/:deckId/cards", handlers.AddCardToDeck)
 			decks.DELETE("/:deckId", handlers.DeleteDeck)
 			decks.DELETE("/:deckId/cards/:cardId", handlers.RemoveCardFromDeck)
+			decks.GET("/:deckId/stats", handlers.GetDeckStats)
 		}
 	}
 

--- a/backend/services/stats_service_test.go
+++ b/backend/services/stats_service_test.go
@@ -14,11 +14,13 @@ func TestCountCardTypes(t *testing.T) {
 		{Card: models.Card{Type: "Trap"}, Quantity: 1},
 	}
 
-	monsters, spells, traps := countCardTypes(cards)
+	monsterCount := countCardTypes(cards, "monster")
+	spellCount := countCardTypes(cards, "spell")
+	trapCount := countCardTypes(cards, "trap")
 
-	assert.Equal(t, 3, monsters)
-	assert.Equal(t, 2, spells)
-	assert.Equal(t, 1, traps)
+	assert.Equal(t, 3, monsterCount)
+	assert.Equal(t, 2, spellCount)
+	assert.Equal(t, 1, trapCount)
 }
 
 func TestCountMonsterAttributes(t *testing.T) {

--- a/backend/services/stats_service_test.go
+++ b/backend/services/stats_service_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestCountCardTypes(t *testing.T) {
-	userCards := []models.UserCard{
+	cards := []CardWithQuantity{
 		{Card: models.Card{Type: "Monster"}, Quantity: 3},
 		{Card: models.Card{Type: "Spell Card"}, Quantity: 2},
 		{Card: models.Card{Type: "Trap"}, Quantity: 1},
 	}
 
-	monsters, spells, traps := countCardTypes(userCards)
+	monsters, spells, traps := countCardTypes(cards)
 
 	assert.Equal(t, 3, monsters)
 	assert.Equal(t, 2, spells)
@@ -22,7 +22,7 @@ func TestCountCardTypes(t *testing.T) {
 }
 
 func TestCountMonsterAttributes(t *testing.T) {
-	userCards := []models.UserCard{
+	cards := []CardWithQuantity{
 		{
 			Quantity: 2,
 			Card: models.Card{
@@ -39,14 +39,14 @@ func TestCountMonsterAttributes(t *testing.T) {
 		},
 	}
 
-	attrs := countMonsterAttributes(userCards)
+	attrs := countMonsterAttributes(cards)
 
 	assert.Equal(t, 2, attrs["DARK"])
 	assert.Equal(t, 1, attrs["LIGHT"])
 }
 
 func TestComputeAverageStats(t *testing.T) {
-	userCards := []models.UserCard{
+	cards := []CardWithQuantity{
 		{
 			Quantity: 2,
 			Card: models.Card{
@@ -63,7 +63,7 @@ func TestComputeAverageStats(t *testing.T) {
 		},
 	}
 
-	avg := computeAverageStats(userCards)
+	avg := computeAverageStats(cards)
 
 	assert.InEpsilon(t, 1666.6, avg.AvgATK, 0.1)
 	assert.InEpsilon(t, 1400.0, avg.AvgDEF, 0.1)


### PR DESCRIPTION
## 📦 Pull Request: Add Deck Stats Calculation & Shared Logic Refactor

### ✅ Summary

- Added support for calculating **deck statistics** via `CalculateDeckStats`.
- Refactored existing collection stats logic to **reuse shared helper functions**, ensuring consistent behavior and reducing code duplication between deck and collection stats calculation.

This improves maintainability and keeps the logic centralized for both use cases.
